### PR TITLE
fix: 移除 v7 翻译文件中被注入的博彩垃圾内容

### DIFF
--- a/旧版本文件/v7/strings_7.2.0.json
+++ b/旧版本文件/v7/strings_7.2.0.json
@@ -1343,7 +1343,7 @@
     "IssueTrackerCreateForm-SubmitLabelIssue":"创建问题",
     "FileHistory-BlameButtonLabel":"追责",
     "IssueTrackerError-BadRequest":"错误的请求语法",
-    "IssueTracker-GitLab":"亚搏体育app",
+    "IssueTracker-GitLab":"GitLab",
     "File-CouldNotCreateOutOfRepo":"无法在存储库之外创建文件!",
     "GitFlow-CannotStartHotfixMissingMaster":"{0}分支必须启始热修复",
     "Application":"应用",


### PR DESCRIPTION
## 问题

在 `旧版本文件/v7/strings_7.2.0.json` 中，`IssueTracker-GitLab` 的翻译被恶意篡改为 **"亚搏体育app"**（博彩站点 SEO 注入内容）。

## 修复

将该字段的正确翻译恢复为 **"GitLab"**，与其余翻译风格一致（如 GitHub 相关字段均使用英文原名或标准中文译名）。

## 影响范围

- 文件：`旧版本文件/v7/strings_7.2.0.json`
- 字段：`IssueTracker-GitLab`
- 修改：1 行（亚搏体育app → GitLab）

---

> 此 PR 针对同类 SEO 注入问题的清理，若仓库维护者能顺便审计其他翻译文件是否也有类似污染，感激不尽。